### PR TITLE
Feedback de Samuel y propuesta animaciones burbuja

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13250,6 +13250,14 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-reveal": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/react-reveal/-/react-reveal-1.2.2.tgz",
+      "integrity": "sha512-JCv3fAoU6Z+Lcd8U48bwzm4pMZ79qsedSXYwpwt6lJNtj/v5nKJYZZbw3yhaQPPgYePo3Y0NOCoYOq/jcsisuw==",
+      "requires": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "react-side-effect": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-google-maps": "^9.4.5",
     "react-helmet": "5.2.0",
     "react-i18next": "^8.4.0",
+    "react-reveal": "^1.2.2",
     "react-slick": "^0.23.2",
     "react-spring": "^7.1.3",
     "recompose": "^0.30.0",

--- a/src/components/chipDescription/index.js
+++ b/src/components/chipDescription/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Img from 'gatsby-image'
@@ -7,6 +7,7 @@ import {
 } from '../styledComponents';
 import { translate } from "react-i18next"
 import { Spring } from 'react-spring'
+import Fade from 'react-reveal/Fade';
 
 export const ProcessContainer = styled.div`
   width: 100%;
@@ -55,12 +56,17 @@ export const Bubble = styled.div`
   background-image: linear-gradient(225deg, rgb(246, 156, 52), rgb(255, 255, 255));
 `;
 
-const ChipDescription = ({ id, title, description, image, children, t }) => (
-  <ProcessContainer>
-    <Img className="avatar" sizes={image} />
+class ChipDescription extends PureComponent {
+
+  state = {
+    onScreen: false,
+  }
+
+  renderBubbles = () => (
     <Spring
       from={{ opacity: 0, width: 0, height: 0 }}
-      to={{ opacity: 1, width: 20, height: 20 }}>
+      to={{ opacity: 1, width: 20, height: 20 }}
+    >
       {props => 
         <>
           <Bubble 
@@ -87,15 +93,28 @@ const ChipDescription = ({ id, title, description, image, children, t }) => (
         </>
       }
     </Spring>
-    <div className="detail">
-      <H4>{t(`processes.items.${id}.title`)}</H4>
-      <p>{t(`processes.items.${id}.description`)}</p>
-      <div className="children">
-        { children }
-      </div>
-    </div>
-  </ProcessContainer>
-);
+  )
+
+  render() {
+    const { id, image, children, t } = this.props;
+    const { onScreen } = this.state;
+    return (
+      <Fade wait={1000} left onReveal={() => this.setState({ onScreen: true })}>
+        <ProcessContainer>
+          <Img className="avatar" sizes={image} />
+          { onScreen && this.renderBubbles() }
+          <div className="detail">
+            <H4>{t(`processes.items.${id}.title`)}</H4>
+            <p>{t(`processes.items.${id}.description`)}</p>
+            <div className="children">
+              { children }
+            </div>
+          </div>
+        </ProcessContainer>
+      </Fade>
+    );
+  }
+};
 
 ChipDescription.propTypes = {
   image: PropTypes.object.isRequired,

--- a/src/components/chipDescription/index.js
+++ b/src/components/chipDescription/index.js
@@ -6,6 +6,7 @@ import {
   H4,
 } from '../styledComponents';
 import { translate } from "react-i18next"
+import { Spring } from 'react-spring'
 
 export const ProcessContainer = styled.div`
   width: 100%;
@@ -14,10 +15,12 @@ export const ProcessContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  position: relative;
   .avatar {
     width: 10em;
     height: 10em;
     overflow: visible !important;
+    z-index: 2;
     img{
       border-radius: 50%;
       object-fit: cover !important;
@@ -32,16 +35,64 @@ export const ProcessContainer = styled.div`
     p {
       margin-top: 1em;
     }
+    z-index: 2;
   }
+  div.children {
+    z-index: 2;
+  }
+`;
+
+export const Bubble = styled.div`
+  position: absolute;
+  top: ${({ top }) => top};
+  right: ${({ right }) => right};
+  left: ${({ left }) => left};
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  box-sizing: border-box;
+  border-radius: 50%;
+  z-index: 1;
+  background-image: linear-gradient(225deg, rgb(246, 156, 52), rgb(255, 255, 255));
 `;
 
 const ChipDescription = ({ id, title, description, image, children, t }) => (
   <ProcessContainer>
     <Img className="avatar" sizes={image} />
+    <Spring
+      from={{ opacity: 0, width: 0, height: 0 }}
+      to={{ opacity: 1, width: 20, height: 20 }}>
+      {props => 
+        <>
+          <Bubble 
+            top={'-10%'}
+            left={0}
+            right={'5%'}
+            width={`${props.width}em`}
+            height={`${props.height}em`}
+          />
+          <Bubble 
+            top={'30%'}
+            left={'-5%'}
+            right={0}
+            width={`${props.width * .7}em`}
+            height={`${props.height * .7}em`}
+          />
+          <Bubble 
+            top={'25%'}
+            left={'none'}
+            right={'-7%'}
+            width={`${props.width * .7}em`}
+            height={`${props.height * .7}em`}
+          />
+        </>
+      }
+    </Spring>
     <div className="detail">
       <H4>{t(`processes.items.${id}.title`)}</H4>
       <p>{t(`processes.items.${id}.description`)}</p>
-      { children }
+      <div className="children">
+        { children }
+      </div>
     </div>
   </ProcessContainer>
 );

--- a/src/components/header/styledComponents.js
+++ b/src/components/header/styledComponents.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import breakpoint from 'styled-components-breakpoint';
 
 export const HeaderContainer = styled.div`
   position: fixed;
@@ -15,7 +16,10 @@ export const HeaderContainer = styled.div`
 	transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
   ${(props) => props.isWhite && css`
     background: white;
-    height: 70px;
+    height: 100px;
+    ${breakpoint('desktop')`
+      height: 70px;
+    `}
     -webkit-box-shadow: 0px 6px 8px -6px rgba(0,0,0,0.07);
     -moz-box-shadow: 0px 6px 8px -6px rgba(0,0,0,0.07);
     box-shadow: 0px 6px 8px -6px rgba(0,0,0,0.07);

--- a/src/components/header/styledComponents.js
+++ b/src/components/header/styledComponents.js
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import breakpoint from 'styled-components-breakpoint';
 
 export const HeaderContainer = styled.div`
   position: fixed;
@@ -16,10 +15,7 @@ export const HeaderContainer = styled.div`
 	transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
   ${(props) => props.isWhite && css`
     background: white;
-    height: 100px;
-    ${breakpoint('desktop')`
-      height: 70px;
-    `}
+    height: 70px;
     -webkit-box-shadow: 0px 6px 8px -6px rgba(0,0,0,0.07);
     -moz-box-shadow: 0px 6px 8px -6px rgba(0,0,0,0.07);
     box-shadow: 0px 6px 8px -6px rgba(0,0,0,0.07);

--- a/src/components/mapSelector/styledComponents.js
+++ b/src/components/mapSelector/styledComponents.js
@@ -36,7 +36,7 @@ export const ButtonSelector = styled.button`
 `;
 
 export const SectionContainer = styled.section`
-  padding-top: 5em;
+  padding-top: 3em;
   width: 100%;
   height: auto;
   display: flex;
@@ -59,7 +59,7 @@ export const SectionContainer = styled.section`
     height: 65vh;
   }
   ${H3}.section-heading {
-    margin-bottom: 3em;
+    margin-bottom: 1em;
   }
 `;
 

--- a/src/components/process/FloatingChip.js
+++ b/src/components/process/FloatingChip.js
@@ -85,10 +85,12 @@ export const ChipContainer = styled.div`
       transition: all ${({ duration }) => duration}s ease-in-out;
       animation: ${float} ${({ duration }) => duration}s ease-in-out infinite;
       border-radius: 50%;
+      background-color: white;
       box-sizing: border-box;
       display: flex;
       justify-content: center;
       align-items: center;
+      z-index: 2;
       &:hover {
         animation: none;
       }

--- a/src/components/process/FloatingChip.js
+++ b/src/components/process/FloatingChip.js
@@ -85,7 +85,7 @@ export const ChipContainer = styled.div`
       transition: all ${({ duration }) => duration}s ease-in-out;
       animation: ${float} ${({ duration }) => duration}s ease-in-out infinite;
       border-radius: 50%;
-      padding: 0.1em;
+      box-sizing: border-box;
       display: flex;
       justify-content: center;
       align-items: center;

--- a/src/components/process/index.js
+++ b/src/components/process/index.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import {
   EnhancedProcessContainer,

--- a/src/components/process/index.js
+++ b/src/components/process/index.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { PureComponent, Component } from 'react'
 import PropTypes from 'prop-types'
 import {
   EnhancedProcessContainer,
@@ -7,7 +7,7 @@ import ChipDescription from '../chipDescription';
 import FloatingChip from './FloatingChip';
 
 
-export class Process extends PureComponent {
+export class Process extends Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
     process: PropTypes.object.isRequired,

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -51,6 +51,10 @@ function SEO({ description, lang, meta, keywords, title }) {
                 name: 'twitter:description',
                 content: metaDescription,
               },
+              {
+                name: 'viewport',
+                content: "width=device-width, initial-scale=1, minimum-scale=1.0, user-scalable=no",
+              }
             ]
               .concat(
                 keywords.length > 0

--- a/src/utils/styledComponents.js
+++ b/src/utils/styledComponents.js
@@ -68,7 +68,7 @@ export const PageSizer = styled.div`
 `;
 
 export const WhatWeDo = styled(PageSizer)`
-  padding-top: 5em;
+  padding-top: 3em;
   width: 100%;
   height: auto;
   display: flex;
@@ -76,14 +76,13 @@ export const WhatWeDo = styled(PageSizer)`
   justify-content: space-around;
   align-items: center;
   div.processes {
-    margin-top: 5em;
     display: flex;
     flex-direction: column;
     justify-content: center;
     margin: 2em;
     ${breakpoint('desktop')`
       flex-direction: row;
-      margin-top: 5em;
+      margin-top: 2em;
       justify-content: space-between;
     `}
   }


### PR DESCRIPTION
Este PR contiene:

- En móvil, el logo no está centrado verticalmente en la barra del menú.
- Los círculos de las tecnologías se ven ovalados en móvil.
- Reduciría un pelo el espacio que hay antes de `What we do` tanto en móvil como en desktop.
- Lo mismo con `Or stop by our offices`, reduciría el espacio que hay antes y después de ese título.
- Agregando react-reveal@^1.2.2
- Agregando burbujas animadas como fondo detrás de items de sección que hacemos.

Todos resueltos, se debe probar móvil en despliegue desde dispositivo físico.